### PR TITLE
feat: Run tests only for changed file types

### DIFF
--- a/test-es-lint.yml
+++ b/test-es-lint.yml
@@ -6,4 +6,8 @@ test-es-lint:
   rules:
     - if: $RESET_JOB == 'true'
       when: never
+    - if: $CI_COMMIT_BRANCH == $BASE_BRANCH
     - if: $CI_COMMIT_AUTHOR != 'Renovate Bot <dev@t3.xima-services.net>' || $CI_COMMIT_BRANCH !~ /^renovate.*$/
+      changes:
+        - "**/*.js"
+        - "**/*.ts"

--- a/test-html-lint.yml
+++ b/test-html-lint.yml
@@ -6,4 +6,7 @@ test-html-lint:
   rules:
     - if: $RESET_JOB == 'true'
       when: never
+    - if: $CI_COMMIT_BRANCH == $BASE_BRANCH
     - if: $CI_COMMIT_AUTHOR != 'Renovate Bot <dev@t3.xima-services.net>' || $CI_COMMIT_BRANCH !~ /^renovate.*$/
+      changes:
+        - "**/*.html"

--- a/test-php-cs-fixer.yml
+++ b/test-php-cs-fixer.yml
@@ -6,7 +6,10 @@ test-php-cs-fixer:
   rules:
     - if: $RESET_JOB == 'true'
       when: never
+    - if: $CI_COMMIT_BRANCH == $BASE_BRANCH
     - if: $CI_COMMIT_AUTHOR != 'Renovate Bot <dev@t3.xima-services.net>' || $CI_COMMIT_BRANCH !~ /^renovate.*$/
+      changes:
+        - "**/*.php"
   artifacts:
     when: always
     reports:

--- a/test-php-functional.yml
+++ b/test-php-functional.yml
@@ -14,7 +14,10 @@ test-php-functional:
   rules:
     - if: $RESET_JOB == 'true'
       when: never
+    - if: $CI_COMMIT_BRANCH == $BASE_BRANCH
     - if: $CI_COMMIT_AUTHOR != 'Renovate Bot <dev@t3.xima-services.net>' || $CI_COMMIT_BRANCH !~ /^renovate.*$/
+      changes:
+        - "**/*.php"
   artifacts:
     when: always
     reports:

--- a/test-php-lint.yml
+++ b/test-php-lint.yml
@@ -5,4 +5,7 @@ test-php-lint:
   rules:
     - if: $RESET_JOB == 'true'
       when: never
+    - if: $CI_COMMIT_BRANCH == $BASE_BRANCH
     - if: $CI_COMMIT_AUTHOR != 'Renovate Bot <dev@t3.xima-services.net>' || $CI_COMMIT_BRANCH !~ /^renovate.*$/
+      changes:
+        - "**/*.php"

--- a/test-php-stan.yml
+++ b/test-php-stan.yml
@@ -6,7 +6,10 @@ test-php-stan:
   rules:
     - if: $RESET_JOB == 'true'
       when: never
+    - if: $CI_COMMIT_BRANCH == $BASE_BRANCH
     - if: $CI_COMMIT_AUTHOR != 'Renovate Bot <dev@t3.xima-services.net>' || $CI_COMMIT_BRANCH !~ /^renovate.*$/
+      changes:
+          - "**/*.php"
   artifacts:
     when: always
     reports:

--- a/test-php-unit.yml
+++ b/test-php-unit.yml
@@ -9,7 +9,10 @@ test-php-unit:
   rules:
     - if: $RESET_JOB == 'true'
       when: never
+    - if: $CI_COMMIT_BRANCH == $BASE_BRANCH
     - if: $CI_COMMIT_AUTHOR != 'Renovate Bot <dev@t3.xima-services.net>' || $CI_COMMIT_BRANCH !~ /^renovate.*$/
+      changes:
+        - "**/*.php"
   artifacts:
     when: always
     reports:

--- a/test-typescript-lint.yml
+++ b/test-typescript-lint.yml
@@ -6,4 +6,7 @@ test-typescript-lint:
   rules:
     - if: $RESET_JOB == 'true'
       when: never
+    - if: $CI_COMMIT_BRANCH == $BASE_BRANCH
     - if: $CI_COMMIT_AUTHOR != 'Renovate Bot <dev@t3.xima-services.net>' || $CI_COMMIT_BRANCH !~ /^renovate.*$/
+      changes:
+        - "**/*.ts"

--- a/test-typoscript-lint.yml
+++ b/test-typoscript-lint.yml
@@ -9,4 +9,9 @@ test-typoscript-lint:
   rules:
     - if: $RESET_JOB == 'true'
       when: never
+    - if: $CI_COMMIT_BRANCH == $BASE_BRANCH
     - if: $CI_COMMIT_AUTHOR != 'Renovate Bot <dev@t3.xima-services.net>' || $CI_COMMIT_BRANCH !~ /^renovate.*$/
+      changes:
+        - "**/*.typoscript"
+        - "**/*.tsconfig"
+        - "**/Configuration/**/*.ts"

--- a/test-xml-lint.yml
+++ b/test-xml-lint.yml
@@ -10,4 +10,7 @@ test-xml-lint:
   rules:
     - if: $RESET_JOB == 'true'
       when: never
+    - if: $CI_COMMIT_BRANCH == $BASE_BRANCH
     - if: $CI_COMMIT_AUTHOR != 'Renovate Bot <dev@t3.xima-services.net>' || $CI_COMMIT_BRANCH !~ /^renovate.*$/
+      changes:
+        - "**/*.xlf"

--- a/test-yaml-lint.yml
+++ b/test-yaml-lint.yml
@@ -5,4 +5,8 @@ test-yaml-lint:
   rules:
     - if: $RESET_JOB == 'true'
       when: never
+    - if: $CI_COMMIT_BRANCH == $BASE_BRANCH
     - if: $CI_COMMIT_AUTHOR != 'Renovate Bot <dev@t3.xima-services.net>' || $CI_COMMIT_BRANCH !~ /^renovate.*$/
+      changes:
+        - "**/*.yml"
+        - "**/*.yaml"


### PR DESCRIPTION
Use the `changes` keyword to make the tests run only when changes to the specific file type have been made. Additionally, always run all tests for `BASE_BRANCH`.