### PR TITLE
fix: do not run tests on tag pipelines

### DIFF
--- a/test-es-lint.yml
+++ b/test-es-lint.yml
@@ -6,6 +6,8 @@ test-es-lint:
   rules:
     - if: $RESET_JOB == 'true'
       when: never
+    - if: $CI_COMMIT_TAG && $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/
+      when: never
     - if: $CI_COMMIT_BRANCH == $BASE_BRANCH
     - if: $CI_COMMIT_AUTHOR != 'Renovate Bot <dev@t3.xima-services.net>' || $CI_COMMIT_BRANCH !~ /^renovate.*$/
       changes:

--- a/test-html-lint.yml
+++ b/test-html-lint.yml
@@ -6,6 +6,8 @@ test-html-lint:
   rules:
     - if: $RESET_JOB == 'true'
       when: never
+    - if: $CI_COMMIT_TAG && $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/
+      when: never
     - if: $CI_COMMIT_BRANCH == $BASE_BRANCH
     - if: $CI_COMMIT_AUTHOR != 'Renovate Bot <dev@t3.xima-services.net>' || $CI_COMMIT_BRANCH !~ /^renovate.*$/
       changes:

--- a/test-php-cs-fixer.yml
+++ b/test-php-cs-fixer.yml
@@ -6,6 +6,8 @@ test-php-cs-fixer:
   rules:
     - if: $RESET_JOB == 'true'
       when: never
+    - if: $CI_COMMIT_TAG && $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/
+      when: never
     - if: $CI_COMMIT_BRANCH == $BASE_BRANCH
     - if: $CI_COMMIT_AUTHOR != 'Renovate Bot <dev@t3.xima-services.net>' || $CI_COMMIT_BRANCH !~ /^renovate.*$/
       changes:

--- a/test-php-functional.yml
+++ b/test-php-functional.yml
@@ -14,6 +14,8 @@ test-php-functional:
   rules:
     - if: $RESET_JOB == 'true'
       when: never
+    - if: $CI_COMMIT_TAG && $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/
+      when: never
     - if: $CI_COMMIT_BRANCH == $BASE_BRANCH
     - if: $CI_COMMIT_AUTHOR != 'Renovate Bot <dev@t3.xima-services.net>' || $CI_COMMIT_BRANCH !~ /^renovate.*$/
       changes:

--- a/test-php-lint.yml
+++ b/test-php-lint.yml
@@ -5,6 +5,8 @@ test-php-lint:
   rules:
     - if: $RESET_JOB == 'true'
       when: never
+    - if: $CI_COMMIT_TAG && $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/
+      when: never
     - if: $CI_COMMIT_BRANCH == $BASE_BRANCH
     - if: $CI_COMMIT_AUTHOR != 'Renovate Bot <dev@t3.xima-services.net>' || $CI_COMMIT_BRANCH !~ /^renovate.*$/
       changes:

--- a/test-php-stan.yml
+++ b/test-php-stan.yml
@@ -6,6 +6,8 @@ test-php-stan:
   rules:
     - if: $RESET_JOB == 'true'
       when: never
+    - if: $CI_COMMIT_TAG && $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/
+      when: never
     - if: $CI_COMMIT_BRANCH == $BASE_BRANCH
     - if: $CI_COMMIT_AUTHOR != 'Renovate Bot <dev@t3.xima-services.net>' || $CI_COMMIT_BRANCH !~ /^renovate.*$/
       changes:

--- a/test-php-unit.yml
+++ b/test-php-unit.yml
@@ -9,6 +9,8 @@ test-php-unit:
   rules:
     - if: $RESET_JOB == 'true'
       when: never
+    - if: $CI_COMMIT_TAG && $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/
+      when: never
     - if: $CI_COMMIT_BRANCH == $BASE_BRANCH
     - if: $CI_COMMIT_AUTHOR != 'Renovate Bot <dev@t3.xima-services.net>' || $CI_COMMIT_BRANCH !~ /^renovate.*$/
       changes:

--- a/test-typescript-lint.yml
+++ b/test-typescript-lint.yml
@@ -6,6 +6,8 @@ test-typescript-lint:
   rules:
     - if: $RESET_JOB == 'true'
       when: never
+    - if: $CI_COMMIT_TAG && $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/
+      when: never
     - if: $CI_COMMIT_BRANCH == $BASE_BRANCH
     - if: $CI_COMMIT_AUTHOR != 'Renovate Bot <dev@t3.xima-services.net>' || $CI_COMMIT_BRANCH !~ /^renovate.*$/
       changes:

--- a/test-typoscript-lint.yml
+++ b/test-typoscript-lint.yml
@@ -9,6 +9,8 @@ test-typoscript-lint:
   rules:
     - if: $RESET_JOB == 'true'
       when: never
+    - if: $CI_COMMIT_TAG && $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/
+      when: never
     - if: $CI_COMMIT_BRANCH == $BASE_BRANCH
     - if: $CI_COMMIT_AUTHOR != 'Renovate Bot <dev@t3.xima-services.net>' || $CI_COMMIT_BRANCH !~ /^renovate.*$/
       changes:

--- a/test-xml-lint.yml
+++ b/test-xml-lint.yml
@@ -10,6 +10,8 @@ test-xml-lint:
   rules:
     - if: $RESET_JOB == 'true'
       when: never
+    - if: $CI_COMMIT_TAG && $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/
+      when: never
     - if: $CI_COMMIT_BRANCH == $BASE_BRANCH
     - if: $CI_COMMIT_AUTHOR != 'Renovate Bot <dev@t3.xima-services.net>' || $CI_COMMIT_BRANCH !~ /^renovate.*$/
       changes:

--- a/test-yaml-lint.yml
+++ b/test-yaml-lint.yml
@@ -5,6 +5,8 @@ test-yaml-lint:
   rules:
     - if: $RESET_JOB == 'true'
       when: never
+    - if: $CI_COMMIT_TAG && $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/
+      when: never
     - if: $CI_COMMIT_BRANCH == $BASE_BRANCH
     - if: $CI_COMMIT_AUTHOR != 'Renovate Bot <dev@t3.xima-services.net>' || $CI_COMMIT_BRANCH !~ /^renovate.*$/
       changes:


### PR DESCRIPTION
Releases are always testet. Tag pipelines are used as deployment trigger. No further tests are needed.