### PR TITLE
Ignore platform requirements via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,24 @@ include:
 
 ## Configure jobs
 
+### `build-php`
+
+You can set custom options for the composer install command via environment variable:
+
+```yaml
+variables:
+  COMPOSER_INSTALL_OPTIONS: "--ignore-platform-req=ext-ldap"
+
+include:
+  - 'https://raw.githubusercontent.com/xima-media/gitlab-templates/main/build-php.yml'
+```
+
+
 ### `build-node`
 
 Add this to your `.gitlab-ci.yml` to configure the node version and asset paths:
 
-```
+```yaml
 build-node:
   image:
     name: node:18.17.1-slim
@@ -61,7 +74,7 @@ build-node:
 
 Add this to your `.gitlab-ci.yml` to configure the node version:
 
-```
+```yaml
 test-es-lint:
   image:
     name: node:18.17.1-slim
@@ -71,7 +84,7 @@ test-es-lint:
 
 Add this to your `.gitlab-ci.yml` to configure the node version:
 
-```
+```yaml
 test-html-lint:
   image:
     name: node:18.17.1-slim

--- a/build-php.yml
+++ b/build-php.yml
@@ -5,7 +5,7 @@ build-php:
       - .composer-cache/
   script:
     - composer config -g cache-dir "$(pwd)/.composer-cache"
-    - composer install --ignore-platform-reqs --optimize-autoloader --no-ansi --no-interaction --no-progress
+    - composer install --optimize-autoloader --no-ansi --no-interaction --no-progress $COMPOSER_INSTALL_OPTIONS
   artifacts:
     paths:
       - vendor/


### PR DESCRIPTION
To make sure the renovate bot does not update to a dependency version that does not apply with the platform environment (e.g. php version), the `--ignore-platform-reqs` option should be removed from the composer install command.
However, there are cases where special requirements are not fulfilled (e.g. `ext-ldap`). To ignore these requirements, a new environment variable `$COMPOSER_INSTALL_OPTIONS` is introduced.

Usage: 

```yaml
variables:
  COMPOSER_INSTALL_OPTIONS: "--ignore-platform-req=ext-ldap"

include:
  - 'https://raw.githubusercontent.com/xima-media/gitlab-templates/main/build-php.yml'
```