### PR TITLE
fix: remove public directory from cache and artifacts

### DIFF
--- a/build-php.yml
+++ b/build-php.yml
@@ -7,12 +7,10 @@ build-php:
       paths:
         - .composer-cache/
         - vendor/
-        - public/
   script:
     - composer config -g cache-dir "$(pwd)/.composer-cache"
     - if [ ! -d "vendor" ]; then composer install --optimize-autoloader --no-ansi --no-interaction --no-progress $COMPOSER_INSTALL_OPTIONS; fi
   artifacts:
     paths:
       - vendor/
-      - public/
     expire_in: 1 day


### PR DESCRIPTION
When caching the `public` path, the `.htaccess` (or `LocalConfiguration` in v11) are only updated when having changes in `composer.lock` due to cache key.

There is no need to cache this directory, can be removed from artifacts as well. 