### PR TITLE
Fix TYPO3 v11 build

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ include:
 
 ### Stage `build`
 * `build-php`
+* `build-php-v11`
 * `build-node` ⚠️ needs configuration
 
 ### Stage `test`

--- a/build-php-v11.yml
+++ b/build-php-v11.yml
@@ -1,0 +1,21 @@
+build-php:
+  stage: build
+  cache:
+    - key: 
+        files: 
+          - composer.lock
+          - public/.htaccess
+          - public/typo3conf/AdditionalConfiguration.php
+          - public/typo3conf/LocalConfiguration.php
+      paths:
+        - .composer-cache/
+        - vendor/
+        - public/
+  script:
+    - composer config -g cache-dir "$(pwd)/.composer-cache"
+    - if [ ! -d "vendor" ]; then composer install --optimize-autoloader --no-ansi --no-interaction --no-progress $COMPOSER_INSTALL_OPTIONS; fi
+  artifacts:
+    paths:
+      - vendor/
+      - public/
+    expire_in: 1 day

--- a/build-php.yml
+++ b/build-php.yml
@@ -4,13 +4,16 @@ build-php:
     - key: 
         files: 
           - composer.lock
+          - public/.htaccess
       paths:
         - .composer-cache/
         - vendor/
+        - public/
   script:
     - composer config -g cache-dir "$(pwd)/.composer-cache"
     - if [ ! -d "vendor" ]; then composer install --optimize-autoloader --no-ansi --no-interaction --no-progress $COMPOSER_INSTALL_OPTIONS; fi
   artifacts:
     paths:
       - vendor/
+      - public/
     expire_in: 1 day


### PR DESCRIPTION
This PR adds a separate gitlab template for TYPO3 v11: In this legacy version, the configuration files are stored inside the cached `public` directory. Since files for cache keys need to exist, this file only has a different cache key setting.