### PR TITLE
feat: add ci:language:lint test step

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ include:
   - 'https://raw.githubusercontent.com/xima-media/gitlab-templates/1.0.0/test-editorconfig-lint'
   - 'https://raw.githubusercontent.com/xima-media/gitlab-templates/1.0.0/test-composer-sitepackage.yml'
   - 'https://raw.githubusercontent.com/xima-media/gitlab-templates/1.0.0/test-es-lint.yml'
+  - 'https://raw.githubusercontent.com/xima-media/gitlab-templates/1.0.0/test-language-lint'
   - 'https://raw.githubusercontent.com/xima-media/gitlab-templates/1.0.0/test-html-lint.yml'
   - 'https://raw.githubusercontent.com/xima-media/gitlab-templates/1.0.0/test-php-lint.yml'
   - 'https://raw.githubusercontent.com/xima-media/gitlab-templates/1.0.0/test-php-cs-fixer.yml'
@@ -38,6 +39,7 @@ include:
 * `test-composer-sitepackage` ⚠️ needs configuration
 * `test-es-lint` ⚠️ needs configuration
 * `test-html-lint` ⚠️ needs configuration
+* `test-language-lint`
 * `test-php-lint`
 * `test-php-cs-fixer`
 * `test-php-stan`

--- a/test-language-lint.yml
+++ b/test-language-lint.yml
@@ -1,0 +1,14 @@
+test-language-lint:
+  stage: test
+  needs: [ "build-php" ]
+  script:
+    - composer run ci:language:lint
+  rules:
+    - if: $RESET_JOB == 'true'
+      when: never
+    - if: $CI_COMMIT_TAG && $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/
+      when: never
+    - if: $CI_COMMIT_BRANCH == $BASE_BRANCH
+    - if: $CI_COMMIT_AUTHOR != 'Renovate Bot <dev@t3.xima-services.net>' || $CI_COMMIT_BRANCH !~ /^renovate.*$/
+      changes:
+        - "**/*.xlf"


### PR DESCRIPTION
Add test step for `ci:language:lint` command using [move-elevator/composer-translation-validator](https://github.com/move-elevator/composer-translation-validator).