### PR TITLE
feat: enable manual execution of reset jobs

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -213,19 +213,21 @@ reset-upload-live:
   extends: .deploy-prepare
   variables:
   script:
+    # use "stage=live" as default if not defined
+    - RESET_UPLOAD_SELECTOR="${RESET_UPLOAD_SELECTOR:-stage=live}"
     # install rclone and jq
     - apk add --update --quiet rclone jq && rclone version && jq --version
     # get ssh connection params from deploy.php
-    - SFTP_HOST=$(vendor/bin/dep config --format json $[[ inputs.live_host_selector ]] | jq -r '.[].hostname')
-    - SFTP_USER=$(vendor/bin/dep config --format json $[[ inputs.live_host_selector ]] | jq -r '.[].remote_user')
-    - DEPLOY_PATH=$(vendor/bin/dep config --format json $[[ inputs.live_host_selector ]] | jq -r '.[].deploy_path')
+    - SFTP_HOST=$(vendor/bin/dep config --format json ${RESET_UPLOAD_SELECTOR} | jq -r '.[].hostname')
+    - SFTP_USER=$(vendor/bin/dep config --format json ${RESET_UPLOAD_SELECTOR} | jq -r '.[].remote_user')
+    - DEPLOY_PATH=$(vendor/bin/dep config --format json ${RESET_UPLOAD_SELECTOR} | jq -r '.[].deploy_path')
     # set up rclone remotes
     - !reference [.reset-prepare, script]
     # dump database on source
-    - vendor/bin/dep db:rmdump "$[[ inputs.live_host_selector ]]" --options=dumpcode:resetJob --no-interaction -vvv
-    - vendor/bin/dep db:export "$[[ inputs.live_host_selector ]]" --options=dumpcode:resetJob --no-interaction -vvv
-    - vendor/bin/dep db:process "$[[ inputs.live_host_selector ]]" --options=dumpcode:resetJob --no-interaction -vvv
-    - vendor/bin/dep db:compress "$[[ inputs.live_host_selector ]]" --options=dumpcode:resetJob --no-interaction -vvv
+    - vendor/bin/dep db:rmdump "${RESET_UPLOAD_SELECTOR}" --options=dumpcode:resetJob --no-interaction -vvv
+    - vendor/bin/dep db:export "${RESET_UPLOAD_SELECTOR}" --options=dumpcode:resetJob --no-interaction -vvv
+    - vendor/bin/dep db:process "${RESET_UPLOAD_SELECTOR}" --options=dumpcode:resetJob --no-interaction -vvv
+    - vendor/bin/dep db:compress "${RESET_UPLOAD_SELECTOR}" --options=dumpcode:resetJob --no-interaction -vvv
     # sync database from sftp remote to crypt remote
     - 'rclone sync -v --inplace --metadata --include "*dumpcode=resetJob*" --delete-excluded "sftp:${DEPLOY_PATH}/.dep/database/dumps/" ${CRYPT_NAME}:.dep/database/dumps'
     # prepare exclude args for rclone
@@ -243,8 +245,6 @@ reset-upload-live:
         sh -c "$CMD"
       done
   rules:
-    - if: '"$[[ inputs.live_deploy_enabled ]]" != "true"'
-      when: never
     - if: '$CI_SERVER_URL != "$[[ inputs.ci_server_url | expand_vars ]]"'
       when: never
     - if: $RESET_JOB == "true" && $RESET_HOST_SELECTOR == null


### PR DESCRIPTION
Remove the requirement of `$CI_PIPELINE_SOURCE == "schedule"` for reset jobs in order to execute them manually via UI.