### PR TITLE
fix: truncate  at underscore to get correct branch id

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Notes about variables:
   * RESET_UPLOAD_SOURCE_SELECTOR == *'hostname'*
   * RESET_DOWNLOAD_TARGET_SELECTOR == *'label=value'*
 * **RESET_UPLOAD_SOURCE_SELECTOR** defaults to *stage=live* when unset.
-* **reset-download-target** aborts if the last deployed commit branch on target does not match `$CI_COMMIT_BRANCH` for which the pipeline is run.
+* **reset-download-target** aborts if the last deployed commit branch on target does not match `BRANCH_ID` (the `$CI_COMMIT_BRANCH` of the pipeline run, normalized by truncating at the first underscore).
 
 Default behaviour:
 * `RESET_JOB == "true"` and `RESET_DOWNLOAD_TARGET_SELECTOR,RESET_UPLOAD_SOURCE_SELECTOR` unset -> triggers **reset-upload-source**

--- a/reset.yml
+++ b/reset.yml
@@ -116,7 +116,6 @@ reset-download-target:
     # ensure the commit branch from which the reset has been triggered matches the last deployed commit branch on target
     - LAST_RELEASE_LOG_LINE=$(vendor/bin/dep run "tail -n 1 ../../.dep/releases_log" "${RESET_DOWNLOAD_TARGET_SELECTOR}")
     - LAST_DEPLOYED_COMMIT_BRANCH=$(echo "$LAST_RELEASE_LOG_LINE" | awk -F'] ' '{print $2}' | jq -r '.target')
-    - BRANCH_ID=${CI_COMMIT_BRANCH%%_*}
     - 'if [ "$LAST_DEPLOYED_COMMIT_BRANCH" != "$BRANCH_ID" ]; then echo "The last deployed commit branch on target ($LAST_DEPLOYED_COMMIT_BRANCH) does not match the commit branch from which the reset job has been triggered ($BRANCH_ID). Aborting reset to prevent potential data loss!"; exit 1; fi'
     # get ssh connection params from deploy.php
     - DEPLOYER_SFTP_HOSTNAME=$(vendor/bin/dep config --format json ${RESET_DOWNLOAD_TARGET_SELECTOR} | jq -r '.[].hostname')

--- a/reset.yml
+++ b/reset.yml
@@ -116,7 +116,8 @@ reset-download-target:
     # ensure the commit branch from which the reset has been triggered matches the last deployed commit branch on target
     - LAST_RELEASE_LOG_LINE=$(vendor/bin/dep run "tail -n 1 ../../.dep/releases_log" "${RESET_DOWNLOAD_TARGET_SELECTOR}")
     - LAST_DEPLOYED_COMMIT_BRANCH=$(echo "$LAST_RELEASE_LOG_LINE" | awk -F'] ' '{print $2}' | jq -r '.target')
-    - 'if [ "$LAST_DEPLOYED_COMMIT_BRANCH" != "$CI_COMMIT_BRANCH" ]; then echo "The last deployed commit branch on target ($LAST_DEPLOYED_COMMIT_BRANCH) does not match the commit branch from which the reset job has been triggered ($CI_COMMIT_BRANCH). Aborting reset to prevent potential data loss!"; exit 1; fi'
+    - BRANCH_ID=${CI_COMMIT_BRANCH%%_*}
+    - 'if [ "$LAST_DEPLOYED_COMMIT_BRANCH" != "$BRANCH_ID" ]; then echo "The last deployed commit branch on target ($LAST_DEPLOYED_COMMIT_BRANCH) does not match the commit branch from which the reset job has been triggered ($BRANCH_ID). Aborting reset to prevent potential data loss!"; exit 1; fi'
     # get ssh connection params from deploy.php
     - DEPLOYER_SFTP_HOSTNAME=$(vendor/bin/dep config --format json ${RESET_DOWNLOAD_TARGET_SELECTOR} | jq -r '.[].hostname')
     - DEPLOYER_SFTP_REMOTE_USER=$(vendor/bin/dep config --format json ${RESET_DOWNLOAD_TARGET_SELECTOR} | jq -r '.[].remote_user')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reset validation by correctly checking the target’s last deployed branch before proceeding.
  * Updated the mismatch message to accurately identify the expected branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->