### PR TITLE
fix: also truncate $LAST_DEPLOYED_COMMIT_BRANCH

### DIFF
--- a/reset.yml
+++ b/reset.yml
@@ -115,7 +115,7 @@ reset-download-target:
     - apk add --update --quiet rclone jq && rclone version && jq --version
     # ensure the commit branch from which the reset has been triggered matches the last deployed commit branch on target
     - LAST_RELEASE_LOG_LINE=$(vendor/bin/dep run "tail -n 1 ../../.dep/releases_log" "${RESET_DOWNLOAD_TARGET_SELECTOR}")
-    - LAST_DEPLOYED_COMMIT_BRANCH=$(echo "$LAST_RELEASE_LOG_LINE" | awk -F'] ' '{print $2}' | jq -r '.target')
+    - LAST_DEPLOYED_COMMIT_BRANCH=$(echo "$LAST_RELEASE_LOG_LINE" | awk -F'] ' '{print $2}' | jq -r '.target'); LAST_DEPLOYED_COMMIT_BRANCH=${LAST_DEPLOYED_COMMIT_BRANCH%%_*}
     - 'if [ "$LAST_DEPLOYED_COMMIT_BRANCH" != "$BRANCH_ID" ]; then echo "The last deployed commit branch on target ($LAST_DEPLOYED_COMMIT_BRANCH) does not match the commit branch from which the reset job has been triggered ($BRANCH_ID). Aborting reset to prevent potential data loss!"; exit 1; fi'
     # get ssh connection params from deploy.php
     - DEPLOYER_SFTP_HOSTNAME=$(vendor/bin/dep config --format json ${RESET_DOWNLOAD_TARGET_SELECTOR} | jq -r '.[].hostname')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved branch target handling during reset operations by removing suffixes after the first underscore.
  * Helps ensure resets proceed only when the intended branch matches, reducing the risk of unintended data loss.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->