### PR TITLE
fix(reset): drop stale processed files on the reset target

### DIFF
--- a/reset.yml
+++ b/reset.yml
@@ -141,5 +141,9 @@ reset-download-target:
     - vendor/bin/dep db:process "${RESET_DOWNLOAD_TARGET_SELECTOR}" --options=dumpcode:resetJob --no-interaction -vvv
     - vendor/bin/dep db:import "${RESET_DOWNLOAD_TARGET_SELECTOR}" --options=dumpcode:resetJob --no-interaction -vvv
     - vendor/bin/dep db:rmdump "${RESET_DOWNLOAD_TARGET_SELECTOR}" --options=dumpcode:resetJob --no-interaction -vvv
+    # sys_file_processedfile is excluded from the dump, so the target keeps its own rows while
+    # sys_file.sha1 is replaced by the source values. The stale originalfilesha1 then makes TYPO3
+    # flag the processed file as deleted and never restore the flag ("File has been deleted.").
+    - vendor/bin/dep run "{{bin/php}} {{local/bin/typo3}} cleanup:localprocessedfiles --all --force" "${RESET_DOWNLOAD_TARGET_SELECTOR}" --no-interaction -vvv
   rules:
     - if: $RESET_JOB == "true" && $RESET_DOWNLOAD_TARGET_SELECTOR != null

--- a/reset.yml
+++ b/reset.yml
@@ -144,6 +144,6 @@ reset-download-target:
     # sys_file_processedfile is excluded from the dump, so the target keeps its own rows while
     # sys_file.sha1 is replaced by the source values. The stale originalfilesha1 then makes TYPO3
     # flag the processed file as deleted and never restore the flag ("File has been deleted.").
-    - vendor/bin/dep run "{{bin/php}} {{local/bin/typo3}} cleanup:localprocessedfiles --all --force" "${RESET_DOWNLOAD_TARGET_SELECTOR}" --no-interaction -vvv
+    - vendor/bin/dep run "{{bin/php}} {{local/bin/typo3}} cleanup:localprocessedfiles --force" "${RESET_DOWNLOAD_TARGET_SELECTOR}" --no-interaction -vvv
   rules:
     - if: $RESET_JOB == "true" && $RESET_DOWNLOAD_TARGET_SELECTOR != null


### PR DESCRIPTION
sys_file_processedfile sits in the default ignore_tables_out of sourcebroker/deployer-typo3-database, so the dump carries no rows for it and the target keeps its own. After the import those rows point at the old originalfilesha1 while sys_file.sha1 holds the source value, so ProcessedFile::needsReprocessing() flags the record deleted and only updateWithLocalFile() would clear the flag again - which the early return in LocalImageProcessor never reaches. The frontend then dies with "File has been deleted." (1329821486).

Projects using ichhabrecht/filefill hit this hardest: filefill re-downloads the processed file inside exists(), so the delete() branch is taken and the leftover file in _processed_ survives every reset (the rclone copy never deletes).

Run cleanup:localprocessedfiles --all after the import to drop both the records and the files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database reset reliability by reconciling processed files after imports.
  * Helps ensure file states remain consistent following a reset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->